### PR TITLE
fix: fix python library version error

### DIFF
--- a/chapter08/docker/movielens-api/requirements.txt
+++ b/chapter08/docker/movielens-api/requirements.txt
@@ -2,3 +2,7 @@ Flask==1.1.1
 pandas==0.25.2
 Flask-HTTPAuth==3.3.0
 click==7.1.2
+numpy==1.23.1
+jinja2==3.0.3
+itsdangerous==2.0.1
+werkzeug==2.0.3


### PR DESCRIPTION
Flask 1.1.1 사용으로 인한 라이브러리 버전 문제 해결